### PR TITLE
Default charset on text files to UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 caches
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 node_modules
 caches
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ For example `{Foo:"42"}` becomes `x-amz-meta-foo:42`.
 
 #### `charset` (String)
 
-Add a charset to your `Content-Type`. For example: `utf-8`.
+Add a charset to every one of your `Content-Type`. For example: `utf-8`. If this is not set, then all text files will get charset of UTF-8 by default.
 
 #### `mime` (Object)
 

--- a/tasks/services/s3.js
+++ b/tasks/services/s3.js
@@ -321,8 +321,9 @@ module.exports = function(grunt) {
       if(!object.ContentType)
         object.ContentType = mime.lookup(dest);
 
-      // Set a default charset
-      if (opts.charset) object.ContentType += '; charset=' + opts.charset;
+      // Set the charset, default text type mime types to UTF-8
+      var charset = mime.charsets.lookup(object.ContentType, '') || opts.charset;
+      if (charset) object.ContentType += '; charset=' + charset;
 
       //upload!
       S3.putObject(object, putComplete);


### PR DESCRIPTION
Previously, you could set the charset, but it applied to all files.
So, if you wanted to add UTF-8 to text files, but not to image files,
you would have to create a different task for each. This fixes that
by using the mime library to apply the default charset to Content-Type
based on mime type... but so far this only adds UTF-8 to text files.