### PR TITLE
Feature to allow exclusion of files to upload (black list)

### DIFF
--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -11,7 +11,8 @@ module.exports = function(grunt) {
       options: {
         accessKeyId: "<%= aws.accessKeyId %>",
         secretAccessKey: "<%= aws.secretAccessKey %>",
-        bucket: "..."
+        bucket: "...",
+        exclude: "dirty.js"
       },
       build: {
         cwd: "build",

--- a/example/build/dirty.js
+++ b/example/build/dirty.js
@@ -1,0 +1,1 @@
+// don't want !

--- a/example/package.json
+++ b/example/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "grunt": "~0.4.1"
+  },
+  "devDependencies": {
+    "grunt-aws": "file:../"
   }
 }

--- a/tasks/services/s3.js
+++ b/tasks/services/s3.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
         var cwd = file.cwd || '';
         files = files.concat(file.src
           .filter(function(src) {
-            return opts.exclude && opts.exclude.indexOf(src) != -1;
+            return opts.exclude && opts.exclude.indexOf(src) == -1;
           })
           .map(function(src) {
             var s = path.join(cwd, src),

--- a/tasks/services/s3.js
+++ b/tasks/services/s3.js
@@ -32,15 +32,22 @@ module.exports = function(grunt) {
   //s3 task
   grunt.registerMultiTask("s3", DESC, function() {
 
+    //get options
+    var opts = this.options(DEFAULTS);
+
     //normalize files array (force expand)
     var files = [];
     this.files.forEach(function(file) {
-      var cwd = file.cwd || '';
-      files = files.concat(file.src.map(function(src) {
-        var s = path.join(cwd, src),
-            d = (cwd||file.src.length>1) ? ((file.dest||'')+src) : file.dest || src;
-        return {src: s, dest: d};
-      }));
+        var cwd = file.cwd || '';
+        files = files.concat(file.src
+          .filter(function(src) {
+            return opts.exclude && opts.exclude.indexOf(src) != -1;
+          })
+          .map(function(src) {
+            var s = path.join(cwd, src),
+              d = (cwd || file.src.length > 1) ? ((file.dest || '') + src) : file.dest || src;
+            return {src: s, dest: d};
+          }));
     });
 
     //skip directories since there are only files on s3
@@ -50,8 +57,6 @@ module.exports = function(grunt) {
 
     //mark as async
     var done = this.async();
-    //get options
-    var opts = this.options(DEFAULTS);
 
     //checks
     if(!opts.bucket)


### PR DESCRIPTION
This is a quick and dirty way to black list a file to avoid the S3 upload. For my scenario I build an index.html that I want to upload separately because it has different properties (different cache control for example).

The current code most likely does not support directories and wildcards...