### PR TITLE
Fix issue creating buckets on us-standar

### DIFF
--- a/tasks/services/s3.js
+++ b/tasks/services/s3.js
@@ -179,6 +179,12 @@ module.exports = function(grunt) {
     //------------------------------------------------
 
     function createBucket(callback) {
+      var params = {
+        Bucket: opts.bucket,
+        ACL: opts.access
+      };
+      if (opts.region && opts.region !== 'us-east-1')
+          params.CreateBucketConfiguration = { LocationConstraint: opts.region };
       //check the bucket doesn't exist first
       S3.listBuckets(function(err, data){
         if(err) {
@@ -195,11 +201,7 @@ module.exports = function(grunt) {
           grunt.log.writeln('Creating bucket ' + opts.bucket + '...');
           //create the bucket using the bucket, access and region options
           if (opts.dryRun) return callback();
-          S3.createBucket({
-            Bucket: opts.bucket,
-            ACL: opts.access,
-            CreateBucketConfiguration: { LocationConstraint: opts.region }
-          }, function(err, data){
+          S3.createBucket(params, function(err, data){
             if(err) {
               err.message = 'createBucket:S3.listBuckets:S3.createBucket: ' + err.message;
               return callback(err);


### PR DESCRIPTION
I added a check to see if a region is passed and if is us-east-1 (us standard) don't pass it since it's the default and it will throw an error.

Also the aws sdk doc says that region its optional but the actual optional part is the CreateBucketConfiguration since if you pass any value to region that its not in what they defined it will throw an error including undefined (the value that it will have if you don't specify a region).