### PR TITLE
Reverse cloudfront subtask order

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "amazon",
     "aws",
     "s3",
+    "cloudfront",
     "cache",
     "caching",
     "gzip",

--- a/tasks/services/cloudfront.js
+++ b/tasks/services/cloudfront.js
@@ -27,13 +27,13 @@ module.exports = function(grunt) {
       'accessKeyId',
       'secretAccessKey'
     ), true);
- 
+
     //cloudfront client
     var cloudfront = new AWS.CloudFront();
 
     var subtasks = [];
-    subtasks.push(createInvalidations);
     subtasks.push(createUpdates);
+    subtasks.push(createInvalidations);
     async.series(subtasks, done);
 
     //------------------------------------------------


### PR DESCRIPTION
I've had a few cases where an invalidation when changing the origin resulted in 404s and I believe it is because the subtasks in cloudfront are reversed, invalidation should always be the last step.
