### PR TITLE
update package.json main to point to the aws file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/jpillora/grunt-aws/issues"
   },
   "licenses": "MIT",
-  "main": "Gruntfile.js",
+  "main": "tasks/aws.js",
   "peerDependencies": {
     "grunt": ">=0.4.0"
   },


### PR DESCRIPTION
The `package.json` main field isnt point to anything and gives an error when you try to require it.

```
❯❯❯ ls node_modules/grunt-aws
README.md    caches       example      node_modules package.json tasks
❯❯❯ node
> require('grunt-aws')
Error: Cannot find module 'grunt-aws'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at repl:1:1
    at REPLServer.defaultEval (repl.js:269:27)
    at bound (domain.js:287:14)
    at REPLServer.runBound [as eval] (domain.js:300:12)
    at REPLServer.<anonymous> (repl.js:439:12)
    at emitOne (events.js:95:20)
> require('grunt-aws/tasks/aws')
[Function]
```