### PR TITLE
Move from _.detect to _.find

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-aws",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-aws",
   "description": "A Grunt interface into the Amazon Node.JS SDK",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "homepage": "https://github.com/jpillora/grunt-aws",
   "author": {
     "name": "Jaime Pillora",

--- a/tasks/services/route53.js
+++ b/tasks/services/route53.js
@@ -122,7 +122,7 @@ module.exports = function(grunt) {
         var recordsToCreate = _.select(records, function(record) {
           //check for any Route53 record matching this record's name (with period on the end)
           var checkForName = (record.name || record.Name) + '.';
-          return !_.detect(data.ResourceRecordSets, function(route53RecordData) {
+          return !_.find(data.ResourceRecordSets, function(route53RecordData) {
             return route53RecordData.Name === checkForName;
           });
         });

--- a/tasks/services/s3.js
+++ b/tasks/services/s3.js
@@ -197,7 +197,7 @@ module.exports = function(grunt) {
           err.message = 'createBucket:S3.listBuckets: ' + err.message;
           return callback(err);
         }
-        var existingBucket = _.detect(data.Buckets, function(bucket){
+        var existingBucket = _.find(data.Buckets, function(bucket){
           return opts.bucket === bucket.Name;
         });
         if(existingBucket){


### PR DESCRIPTION
Fixes https://github.com/jpillora/grunt-aws/issues/70

As mentioned by @DanteRPaz, `_.detect` has been removed in major version 4 of lodash. This PR replaces each occurence of `_.detect` with `_.find`.